### PR TITLE
Added melody loop support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Chris Dennis <https://github.com/StarsoftAnalysis>
 James Brown <https://github.com/jbrown123>
 per1234 <https://github.com/per1234>
 Erwan d'Orgeville <https://github.com/edorgeville>
+Emanuele Palombo <https://github.com/elbowz>

--- a/src/NonBlockingRtttl.h
+++ b/src/NonBlockingRtttl.h
@@ -123,8 +123,10 @@ namespace rtttl
  * Parameters:
  *   iPin:        The pin which is connected to the piezo buffer.
  *   iSongBuffer: The string buffer of the RTTTL song.
+ *   iLoopCount:  Number of times the RTTTL song will be playback (default = 1).
+ *   iLoopGap:    Pause of milliseconds between the song repetition (default = 1000ms).
  ****************************************************************************/
-void begin(byte iPin, const char * iSongBuffer);
+void begin(byte iPin, const char * iSongBuffer, byte iLoopCount = 1, unsigned long iLoopGap = 1000);
 
 /****************************************************************************
  * Description:


### PR DESCRIPTION
It allows the possibility to repeat the melody with a chosen gap between repetition.

The number of repetition (`iLoopCount`) and the gap (`iLoopGap`) can be passed to the function `begin` as optional params.

This features was useful in a my little project (https://github.com/elbowz/thumbl-p), but I don't know if can be useful for others or it's well implemented.

I have used `noteDelay` to add the pause/gap between repetition, so I don't know if it's so elegant coding.

Anyway, **thanks** for you very useful and simple (to use) library!  